### PR TITLE
fix flaky test 

### DIFF
--- a/noxy-reverse/pom.xml
+++ b/noxy-reverse/pom.xml
@@ -27,6 +27,12 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.spinn3r.artemis.network</groupId>

--- a/noxy-reverse/src/test/java/com/spinn3r/noxy/reverse/ReverseProxyServiceTest.java
+++ b/noxy-reverse/src/test/java/com/spinn3r/noxy/reverse/ReverseProxyServiceTest.java
@@ -32,7 +32,6 @@ import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.Matchers.*;
 
@@ -64,7 +63,7 @@ public class ReverseProxyServiceTest extends BaseLauncherTest {
 
     CorporaAsserter corporaAsserter = new CorporaAsserter( getClass() );
 
-    Map<String, Server> httpDaemonMap = new ConcurrentHashMap<>();
+    Map<String, Server> httpDaemonMap = new HashMap<>();
 
     @Override
     @Before

--- a/noxy-reverse/src/test/java/com/spinn3r/noxy/reverse/ReverseProxyServiceTest.java
+++ b/noxy-reverse/src/test/java/com/spinn3r/noxy/reverse/ReverseProxyServiceTest.java
@@ -28,9 +28,11 @@ import org.eclipse.jetty.server.Server;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.Matchers.*;
 
@@ -62,7 +64,7 @@ public class ReverseProxyServiceTest extends BaseLauncherTest {
 
     CorporaAsserter corporaAsserter = new CorporaAsserter( getClass() );
 
-    Map<String, Server> httpDaemonMap = new HashMap<>();
+    Map<String, Server> httpDaemonMap = new ConcurrentHashMap<>();
 
     @Override
     @Before
@@ -175,8 +177,7 @@ public class ReverseProxyServiceTest extends BaseLauncherTest {
 
         content = requestMeta.toJSON();
 
-        corporaAsserter.assertEquals( "testRequestMetaForSuccessfulRequest", content );
-
+        JSONAssert.assertEquals(corporaAsserter.getCorporaCache().read("testRequestMetaForSuccessfulRequest"), content, false);
     }
 
     @Test

--- a/noxy-reverse/src/test/java/com/spinn3r/noxy/reverse/ReverseProxyServiceTest.java
+++ b/noxy-reverse/src/test/java/com/spinn3r/noxy/reverse/ReverseProxyServiceTest.java
@@ -176,7 +176,7 @@ public class ReverseProxyServiceTest extends BaseLauncherTest {
 
         content = requestMeta.toJSON();
 
-        JSONAssert.assertEquals(corporaAsserter.getCorporaCache().read("testRequestMetaForSuccessfulRequest"), content, false);
+        JSONAssert.assertEquals(content,corporaAsserter.getCorporaCache().read("testRequestMetaForSuccessfulRequest"), false);
     }
 
     @Test


### PR DESCRIPTION
I was using the NonDex framework to detect some flaky tests

https://github.com/TestingResearchIllinois/NonDex

I see that 

com.spinn3r.noxy.reverse.ReverseProxyServiceTest#testRequestMetaForSuccessfulRequest

this test is flaky, and I made some changes to fix it,  When corporaAsserter is trying to get the data for testRequestMetaForSuccessfulRequest, the return JSON String has different structure with expected array

I changed the corporaAsserter to JSONAssert to solve this issue